### PR TITLE
Allow plugins to run before or after expressions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you are familiar with Blade, React, Vue or similar, you will find the syntax 
 | **propsSlot**            | `String`           | `'props'`                                    | Used to retrieve props passed to slot via `$slots.slotName.props`.               |
 | **parserOptions**        | `Object`           | `{recognizeSelfClosing: true}`               | Pass options to `posthtml-parser`.                                               |
 | **expressions**          | `Object`           | `{}`                                         | Pass options to `posthtml-expressions`.                                          |
-| **plugins**              | `Array`            | `[]`                                         | PostHTML plugins to apply to every parsed component.                             |
+| **plugins**              | `Array\|Object`    | `[]`                                         | PostHTML plugins to [apply](#plugins) to every parsed component.                 |
 | **matcher**              | `Object`           | `[{tag: options.tagPrefix}]`                 | Array of objects used to match tags.                                             |
 | **attrsParserRules**     | `Object`           | `{}`                                         | Additional rules for attributes parser plugin.                                   |
 | **strict**               | `Boolean`          | `true`                                       | Toggle exception throwing.                                                       |
@@ -841,6 +841,35 @@ Result:
 ```
 
 You can add custom rules to define how attributes are parsed - we use [posthtml-attrs-parser](https://github.com/posthtml/posthtml-attrs-parser) to handle them.
+
+
+### Plugins
+
+You can specify whether plugins are applied before or after the `posthtml-expressions` plugin:
+
+```js
+const options = { 
+  plugins: {
+    before: [/* ... */],
+    after: [/* ... */],
+  } 
+};
+```
+
+For backwards compatibility, passing an array will default to applying plugins after the `posthtml-expressions` plugin. The following options are equivalent:
+
+```js
+const options = { 
+  plugins: [/* ... */]
+};
+
+const options = { 
+  plugins: {
+    before: [/* ... */],
+    after: [],
+  } 
+};
+```
 
 ### Advanced attributes configurations
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -154,7 +154,7 @@ export type PostHTMLComponents = {
    *
    * @default []
    */
-  plugins?: Array<() => void>;
+  plugins?: Array<() => void>|Record<'before','after', Array<() => void>>;
 
   /**
    * Array of objects used to match tags.

--- a/src/index.js
+++ b/src/index.js
@@ -140,9 +140,20 @@ module.exports = (options = {}) => tree => {
   options.props = {...options.expressions.locals};
   options.aware = {};
 
+  if (Array.isArray(options.plugins)) {
+    options.plugins = {
+      before: [],
+      after: options.plugins
+    };
+  }
+
   const pushedContent = {};
 
   log('Start of processing..', 'init', 'success');
+
+  if (options.plugins.before.length > 0) {
+      tree = applyPluginsToTree(tree, options.plugins.before);
+  }
 
   return processStacks(
     processPushes(
@@ -169,8 +180,8 @@ function processTree(options) {
   return (tree, messages) => {
     log(`Processing tree number ${processCounter}..`, 'processTree');
 
-    if (options.plugins.length > 0) {
-      tree = applyPluginsToTree(tree, options.plugins);
+    if (options.plugins.after.length > 0) {
+      tree = applyPluginsToTree(tree, options.plugins.after);
     }
 
     match.call(tree, options.matcher, currentNode => {
@@ -217,10 +228,15 @@ function processTree(options) {
       options.expressions.locals = attributes;
       options.expressions.locals.$slots = filledSlots;
       // const plugins = [...options.plugins, expressions(options.expressions)];
+
+      if (options.plugins.before.length > 0) {
+        nextNode = applyPluginsToTree(nextNode, options.plugins.before);
+      }
+
       nextNode = expressions(options.expressions)(nextNode);
 
-      if (options.plugins.length > 0) {
-        nextNode = applyPluginsToTree(nextNode, options.plugins);
+      if (options.plugins.after.length > 0) {
+        nextNode = applyPluginsToTree(nextNode, options.plugins.after);
       }
 
       // Process <yield> tag


### PR DESCRIPTION
Adds a new `{before:[], after: []}` option to the `plugins` config, which allows plugins to run before or after `posthtml-expressions`. 

This is helpful when a plugin needs to modify the AST before expressions are evaluated.

**For example:**

[Maizzle](https://github.com/maizzle) uses `posthtml-components` under the hood. 

I have a `posthtml` plugin that converts Maizzle templates into my web app's native template format (Twig). During conversion, it replaces `<if>` nodes marked with a `twigify` attribute with the corresponding `{%- if -%}` Twig syntax. This plugin must run before `posthtml-expressions`, because I don't want the tagged `<if>` nodes to be evaluated and because `<if>` nodes are removed from the AST when expressions are evaluated, which prevents plugins from processing them later.

I also have another plugin that removes `<script locals>` before they're evaluated. This allows me to use `<script locals>` to inject static placeholder data into prototype templates, while preserving uninterpolated `{{ }}` delimiters in the converted template so they can be filled by my app. This plugin needs to run before `posthtml-expressions`, so `<script locals>` are removed before they're evaluated.

This change is backwards-compatible; docs and tests also updated.  

---

Please note the plugin run order was changed after the 2022 refactor (45f00f5638ab2c08cdff5fc9dda13d9ef01ae0b8). Prior to the refactor, plugins ran before `posthtml-expressions`. This can be seen in code that's currently commented-out:

https://github.com/posthtml/posthtml-components/blob/e1a2361272a60bd8d138e47e25c258ee7fd12040/src/index.js#L219

I'm guessing this was an optimization, e.g. to skip processing nodes that are ultimately removed from the AST by an expression, but just wanted to give you a heads up in case there was some other reason.